### PR TITLE
Add gh pages

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+REACT_APP_BASE_PATH=/chordmaster/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A React web app that lists all popular and not popular chords, keys and songs.
 
+Available [HERE](http://imagitama.github.io/chordmaster).
+
 ## Usage
 
     npm i

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ Available [HERE](http://imagitama.github.io/chordmaster).
     npm i
     npm start
 
+### Alternative
+
+After you have installed Docker and Docker compose, you can run the app with a single command
+
+    docker-compose up
+
 ## About
 
 Technologies:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.7'
+
+services:
+  node:
+    image: node:14.3.0
+    restart: always
+    stdin_open: true
+    ports:
+      - 3335:3000
+    volumes:
+      - .:/client
+    command: bash -c "cd client && yarn install && yarn start"
+    environment:
+      - NODE_ENV=development
+      - CHOKIDAR_USEPOLLING=true

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "chord.guide",
   "description": "A React app that shows chords, keys and more.",
   "version": "1.0.0",
+  "homepage": "http://imagitama.github.io/chordmaster",
   "private": true,
   "dependencies": {
     "@emotion/core": "^10.0.7",
@@ -30,7 +31,9 @@
     "eject": "react-scripts eject",
     "lint": "eslint src/**/*.{js,jsx}",
     "ultimate-guitar-converter": "node tools/ultimate-guitar-converter/main.js",
-    "prettier": "prettier src/**/*.{js,jsx}"
+    "prettier": "prettier src/**/*.{js,jsx}",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d build"
   },
   "eslintConfig": {
     "extends": [
@@ -54,6 +57,7 @@
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.12.1",
     "enzyme-to-json": "^3.3.5",
+    "gh-pages": "^3.0.0",
     "jest-emotion": "^10.0.10",
     "jest-fetch-mock": "^2.1.2",
     "prettier": "^1.18.2"

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,8 @@ import history from './history'
 
 const { store, persistor } = createStore()
 
+const basePath = process.env.REACT_APP_BASE_PATH || undefined;
+
 if (process.env.NODE_ENV === 'production') {
   Sentry.init({
     dsn: 'https://f4afba1340004de7b22b7e7eccbec25c@sentry.io/1427601'
@@ -23,7 +25,7 @@ const render = Component =>
   ReactDOM.render(
     <Provider store={store}>
       <PersistGate loading={null} persistor={persistor}>
-        <Router history={history}>
+        <Router history={history} basename={basePath}>
           <Component />
         </Router>
       </PersistGate>


### PR DESCRIPTION
First of all, I really like your app, thanks for doing it.

I was sad that https://www.chordmaster.info is donw, so I added some config, so you can run `npm run deploy` to release it to GitHub pages.

GitHub pages tldr: Contents of the gh-pages branch get published under https://**username**.github.io/**reponame** path.

I ran it on my fork, so you can check it out:
https://vhermecz.github.io/chordmaster